### PR TITLE
Sticky header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,7 +6,7 @@ export default function Header() {
 
     return (
         <header className={'fixed text-white z-20 bg-black/40 top-0 inset-x-0 hidden sm:flex gap-6 items-center px-4 py-2 transition duration-200 backdrop-blur-sm ' + (scroll > 0 ? 'shadow-md' : 'hover:shadow-md')}>
-            <a href="#heading">
+            <a href="#">
                 <img className="w-8 h-8" src="/lambda.png" alt="lambda" />
             </a>
             <a href="#about" className="no-underline">About</a>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,15 @@
+import {useScroll} from '../util/useScroll';
+
+
+export default function Header() {
+    const scroll = useScroll();
+
+    return (
+        <header className={'fixed text-white z-20 bg-black/40 top-0 inset-x-0 hidden sm:flex gap-6 items-center px-4 py-2 transition duration-200 backdrop-blur-sm ' + (scroll > 0 ? 'shadow-md' : 'hover:shadow-md')}>
+            <img className="w-8 h-8" src="/lambda.png" alt="lambda" />
+            <a href="#about" className="no-underline">About</a>
+            <a href="#faq" className="no-underline">FAQ</a>
+            <a href="#sponsors" className="no-underline">Sponsors</a>
+        </header>
+    )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,7 +6,9 @@ export default function Header() {
 
     return (
         <header className={'fixed text-white z-20 bg-black/40 top-0 inset-x-0 hidden sm:flex gap-6 items-center px-4 py-2 transition duration-200 backdrop-blur-sm ' + (scroll > 0 ? 'shadow-md' : 'hover:shadow-md')}>
-            <img className="w-8 h-8" src="/lambda.png" alt="lambda" />
+            <a href="#heading">
+                <img className="w-8 h-8" src="/lambda.png" alt="lambda" />
+            </a>
             <a href="#about" className="no-underline">About</a>
             <a href="#faq" className="no-underline">FAQ</a>
             <a href="#sponsors" className="no-underline">Sponsors</a>

--- a/components/Heading.tsx
+++ b/components/Heading.tsx
@@ -5,13 +5,6 @@ import {FaEnvelope} from 'react-icons/fa';
 export default function Heading() {
     return (
         <section id="heading" className="text-white text-center h-screen relative flex flex-col items-center justify-center p-5 bg-[url('/bg.svg')] bg-cover bg-center bg-fixed">
-            <header className="absolute bg-black/40 top-0 inset-x-0 hidden sm:flex gap-6 items-center px-4 py-2 hover:shadow-md transition duration-200">
-                <img className="w-8 h-8" src="/lambda.png" alt="lambda" />
-                <a href="#about" className="no-underline">About</a>
-                <a href="#faq" className="no-underline">FAQ</a>
-                <a href="#sponsors" className="no-underline">Sponsors</a>
-            </header>
-
             <div className="flex flex-wrap justify-center gap-3 text-5xl sm:text-8xl font-['Overpass'] tracking-wider mb-2">
                 <img className="w-12 h-12 sm:w-24 sm:h-24" src="/lambda.png" alt="lambda" />
                 <span className="pt-2">GunnHacks 9.0</span>

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -6,10 +6,10 @@ export default function Section(props: SectionProps) {
     const {title, red, id, children} = props;
 
     return (
-        <section id={id} className={"font-['Abel'] text-center " + (red ? 'text-white bg-theme' : 'bg-white')}>
+        <section className={"font-['Abel'] text-center " + (red ? 'text-white bg-theme' : 'bg-white')}>
             <div className="container py-8">
                 {title && (
-                    <h2 className="text-center text-3xl font-bold border-b-2 border-current mb-4">
+                    <h2 id={id} className="before:-mt-16 before:h-16 before:pointer-events-none before:content-'_' before:block text-center text-3xl font-bold border-b-2 border-current mb-4">
                         {title}
                     </h2>
                 )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Header from '../components/Header';
 import Heading from '../components/Heading';
 import About from '../components/About';
 import FAQ from '../components/FAQ';
@@ -14,6 +15,7 @@ export default function Home() {
                 <meta name="description" content="Make, Build, Create & Learn. It’s GunnHacks 9.0, Gunn’s 24‑hour high school hackathon." />
             </Head>
 
+            <Header />
             <Heading />
             <About />
             <FAQ />

--- a/util/useScroll.ts
+++ b/util/useScroll.ts
@@ -1,0 +1,15 @@
+import {useEffect, useState} from 'react';
+
+
+// Returns the current vertical scroll of the window, in pixels.
+export function useScroll() {
+    const [scroll, setScroll] = useState(0);
+
+    useEffect(() => {
+        setScroll(window.scrollY);
+        document.addEventListener('scroll', () => setScroll(window.scrollY));
+        return () => document.removeEventListener('scroll', () => setScroll(window.scrollY));
+    }, []);
+
+    return scroll;
+}


### PR DESCRIPTION
The `::before` hack doesn't quite seem to work, so jumping to sections still covers the section heading.

![image](https://user-images.githubusercontent.com/60120929/200231747-7635c87d-c6c4-4e19-91b8-da642fee2de6.png)
