### PR TITLE
Pseudoelement fix for iOS Safari heading

### DIFF
--- a/app/(landing)/Heading.tsx
+++ b/app/(landing)/Heading.tsx
@@ -9,7 +9,7 @@ const overpass = Overpass({
 
 export default function Heading() {
     return (
-        <section id="heading" className="text-white text-center h-screen relative flex flex-col items-center justify-center p-5 bg-[url('/bg.svg')] bg-cover bg-center bg-fixed">
+        <section id="heading" className="text-white text-center h-screen relative flex flex-col items-center justify-center p-5">
             <div className={'flex flex-wrap justify-center gap-3 text-5xl sm:text-8xl tracking-wider mb-2 ' + overpass.className}>
                 <img className="w-12 h-12 sm:w-24 sm:h-24" src="/lambda.png" alt="lambda" />
                 <span className="pt-2">GunnHacks 9.0</span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export default function Layout(props: {children: ReactNode}) {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <link rel="icon" type="image/png" href="/favicon.png" />
             </head>
-            <body>
+            <body className="after:fixed after:inset-x-0 after:top-0 after:h-screen after:bg-[url('/bg.svg')] after:bg-cover after:bg-center after:-z-10">
                 {props.children}
             </body>
         </html>


### PR DESCRIPTION
This will also add the background to all pages, preparing for `/register`. This is pretty much akin to what we did last year with an absolutely positioned `img` element, but it's still pretty hacky. Hopefully this doesn't introduce too many desktop issues!